### PR TITLE
ci: add riscv64 to wheel build matrix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,6 +42,9 @@ jobs:
           - runner: ubuntu-22.04
             target: ppc64le
             manylinux: auto
+          - runner: ubuntu-22.04
+            target: riscv64
+            manylinux: auto
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
Adds riscv64 to the Linux wheel build matrix, matching the pattern of the existing architectures (x86_64, x86, aarch64, armv7, s390x, ppc64le).

Same change that was recently merged for fastar (#58 in DoctorJohn/fastar). The maturin + QEMU cross-compilation setup handles riscv64 out of the box.

Built successfully on native riscv64 hardware (BananaPi F3, SpacemiT K1, rv64gc).